### PR TITLE
Added a format function to consoleTransport to allow not showing some params in log string

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,18 @@ function filter(level, event, message, meta) {
 }
 ```
 
+#### `map`
+
+Optional function that changes params of log function. Use in case you want to hide some param in a log.
+
+Example:
+
+```js
+function map(level, event, message, meta) {
+  return [level, message, meta];
+}
+```
+
 #### `name`
 
 Defaults to `ConsoleTransport`.

--- a/README.md
+++ b/README.md
@@ -349,13 +349,13 @@ function filter(level, event, message, meta) {
 
 #### `map`
 
-Optional function that changes params of log function. Use in case you want to hide some param in a log.
+Optional function that can customize log string in a console.
 
 Example:
 
 ```js
 function map(level, event, message, meta) {
-  return [level, message, meta];
+  return `${level} - ${message}`;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -347,14 +347,14 @@ function filter(level, event, message, meta) {
 }
 ```
 
-#### `map`
+#### `format`
 
 Optional function that can customize log string in a console.
 
 Example:
 
 ```js
-function map(level, event, message, meta) {
+function format(level, event, message, meta) {
   return `${level} - ${message}`;
 }
 ```

--- a/src/transports/console.js
+++ b/src/transports/console.js
@@ -18,8 +18,8 @@ export default function configureConsoleTransport(options = {}) {
     ? options.filter
     : () => true;
 
-  const map = (typeof options.map !== 'undefined')
-    ? options.map
+  const format = (typeof options.format !== 'undefined')
+    ? options.format
     : null;
 
   const name = (typeof options.name !== 'undefined')
@@ -39,8 +39,8 @@ export default function configureConsoleTransport(options = {}) {
         return cb(null);
       }
 
-      if (map) {
-        useConsole.log(map(level, event, message, meta));
+      if (format) {
+        useConsole.log(format(level, event, message, meta));
       } else {
         useConsole.log(`[${level}]`, event, message, meta);
       }

--- a/src/transports/console.js
+++ b/src/transports/console.js
@@ -18,6 +18,10 @@ export default function configureConsoleTransport(options = {}) {
     ? options.filter
     : () => true;
 
+  const map = (typeof options.map !== 'undefined')
+    ? options.map
+    : null;
+
   const name = (typeof options.name !== 'undefined')
     ? options.name
     : 'ConsoleTransport';
@@ -35,7 +39,8 @@ export default function configureConsoleTransport(options = {}) {
         return cb(null);
       }
 
-      useConsole.log(`[${level}]`, event, message, meta);
+      const params = [`[${level}]`, event, message, meta];
+      useConsole.log(...(map ? map(...params) : params));
 
       cb(null);
     }

--- a/src/transports/console.js
+++ b/src/transports/console.js
@@ -20,7 +20,7 @@ export default function configureConsoleTransport(options = {}) {
 
   const map = (typeof options.map !== 'undefined')
     ? options.map
-    : (...args) => args;
+    : null;
 
   const name = (typeof options.name !== 'undefined')
     ? options.name
@@ -39,7 +39,11 @@ export default function configureConsoleTransport(options = {}) {
         return cb(null);
       }
 
-      useConsole.log(...map(`[${level}]`, event, message, meta));
+      if (map) {
+        useConsole.log(map(level, event, message, meta));
+      } else {
+        useConsole.log(`[${level}]`, event, message, meta);
+      }
 
       cb(null);
     }

--- a/src/transports/console.js
+++ b/src/transports/console.js
@@ -20,7 +20,7 @@ export default function configureConsoleTransport(options = {}) {
 
   const map = (typeof options.map !== 'undefined')
     ? options.map
-    : null;
+    : (...args) => args;
 
   const name = (typeof options.name !== 'undefined')
     ? options.name
@@ -39,8 +39,7 @@ export default function configureConsoleTransport(options = {}) {
         return cb(null);
       }
 
-      const params = [`[${level}]`, event, message, meta];
-      useConsole.log(...(map ? map(...params) : params));
+      useConsole.log(...map(`[${level}]`, event, message, meta));
 
       cb(null);
     }

--- a/test/transports/console.spec.js
+++ b/test/transports/console.spec.js
@@ -80,4 +80,44 @@ describe('Transport :: console', function () {
       }
     ]);
   });
+
+  it('don`t log certain params filtered by log', function () {
+    const logs = [];
+    const fakeConsole = {
+      log(...args) {
+        logs.push({...args});
+      }
+    };
+    const ConsoleTransport = configureConsoleTransport({
+      name: 'MyCustomConsoleTransport',
+      console: fakeConsole,
+      map(level, event, message, meta) {
+        return [level, message, meta]        
+      }
+    });
+    const consoleTransport = new ConsoleTransport();
+    expect(consoleTransport.name).to.equal('MyCustomConsoleTransport');
+
+    consoleTransport.log('Error', 'SomeEvent', 'Error message', { key: 'value' }, () => {});
+    consoleTransport.log('Warning', 'SomeEvent', 'Warn message', { key: 'value' }, () => {});
+    consoleTransport.log('Information', 'SomeEvent', 'Info message', { key: 'value' }, () => {});
+
+    expect(logs).to.eql([
+      {
+        '0': '[Error]',
+        '1': 'Error message',
+        '2': { key: 'value' }
+      },
+      {
+        '0': '[Warning]',
+        '1': 'Warn message',
+        '2': { key: 'value' }
+      },
+      {
+        '0': '[Information]',
+        '1': 'Info message',
+        '2': { key: 'value' }
+      }
+    ]);
+  });
 });

--- a/test/transports/console.spec.js
+++ b/test/transports/console.spec.js
@@ -91,7 +91,7 @@ describe('Transport :: console', function () {
     const ConsoleTransport = configureConsoleTransport({
       name: 'MyCustomConsoleTransport',
       console: fakeConsole,
-      map(level, event, message, meta) {
+      format(level, event, message, meta) {
         return `${level} - ${message} - ${JSON.stringify(meta)}`;    
       }
     });

--- a/test/transports/console.spec.js
+++ b/test/transports/console.spec.js
@@ -81,18 +81,18 @@ describe('Transport :: console', function () {
     ]);
   });
 
-  it('don`t log certain params filtered by log', function () {
+  it('customize logging string', function () {
     const logs = [];
     const fakeConsole = {
-      log(...args) {
-        logs.push({...args});
+      log(log) {
+        logs.push(log);
       }
     };
     const ConsoleTransport = configureConsoleTransport({
       name: 'MyCustomConsoleTransport',
       console: fakeConsole,
       map(level, event, message, meta) {
-        return [level, message, meta]        
+        return `${level} - ${message} - ${JSON.stringify(meta)}`;    
       }
     });
     const consoleTransport = new ConsoleTransport();
@@ -103,21 +103,9 @@ describe('Transport :: console', function () {
     consoleTransport.log('Information', 'SomeEvent', 'Info message', { key: 'value' }, () => {});
 
     expect(logs).to.eql([
-      {
-        '0': '[Error]',
-        '1': 'Error message',
-        '2': { key: 'value' }
-      },
-      {
-        '0': '[Warning]',
-        '1': 'Warn message',
-        '2': { key: 'value' }
-      },
-      {
-        '0': '[Information]',
-        '1': 'Info message',
-        '2': { key: 'value' }
-      }
+      "Error - Error message - {\"key\":\"value\"}",
+      "Warning - Warn message - {\"key\":\"value\"}",
+      "Information - Info message - {\"key\":\"value\"}"
     ]);
   });
 });


### PR DESCRIPTION
# What does this PR do #
* Added a map function to consoleTransport to allow not showing some params in log string

# Why do we need it #
* To simplify logs in console. `event` in v3 log format is a quite bit object and log it to console not always convenient.